### PR TITLE
fix(packages/cli): pacakge manager yarn error

### DIFF
--- a/.changeset/tiny-pumpkins-remain.md
+++ b/.changeset/tiny-pumpkins-remain.md
@@ -1,0 +1,5 @@
+---
+"solidui-cli": patch
+---
+
+fix(packages/cli): pacakge manager yarn error

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -98,7 +98,9 @@ async function installDeps() {
     })
 
     runCommand(
-      `${packageManager as string} install ${PROJECT_DEPS.join(" ")}`,
+      `${packageManager as string} ${
+        packageManager === "yarn" ? "add" : "install"
+      } ${PROJECT_DEPS.join(" ")}`,
       "Installing Solid UI Component dependencies",
       "Dependencies installed"
     )


### PR DESCRIPTION
Package manager yarn gives error on install dependencies
![image](https://github.com/sek-consulting/solid-ui/assets/64685317/e45d4e6b-5c79-4baf-9231-dd106cd9f7c8)

Successful install with yarn add ... (fixed)