### PR TITLE
fix: cards example now correctly showing border for selected item

### DIFF
--- a/apps/docs/src/components/cards/payment-method.tsx
+++ b/apps/docs/src/components/cards/payment-method.tsx
@@ -26,7 +26,7 @@ export function PaymentMethod() {
             <RadioGroupItem value="card" id="card" class="peer sr-only" />
             <Label
               html-for="card"
-              class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary [&:has([data-state=checked])]:border-primary"
+              class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[checked]:border-primary"
             >
               <IconCreditCard class="mb-3 size-6" />
               Card
@@ -36,7 +36,7 @@ export function PaymentMethod() {
             <RadioGroupItem value="paypal" id="paypal" class="peer sr-only" />
             <Label
               html-for="paypal"
-              class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary [&:has([data-state=checked])]:border-primary"
+              class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[checked]:border-primary"
             >
               <IconBrandPaypal class="mb-3 size-6" />
               Paypal
@@ -46,7 +46,7 @@ export function PaymentMethod() {
             <RadioGroupItem value="apple" id="apple" class="peer sr-only" />
             <Label
               html-for="apple"
-              class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary [&:has([data-state=checked])]:border-primary"
+              class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[checked]:border-primary"
             >
               <IconBrandApple class="mb-3 size-6" />
               Apple


### PR DESCRIPTION
Fixed issue with radio group, in the cards example, not correctly showing border for selected item. The `peer-data` selector being used was `peer-data-[state=checked]` which did not work for me in Firefox or Chrome. Following the tailwind documentation I modified it to `peer-data-[checked]` which fixed the issue! 

### **Original:**
<img width="432" alt="Screenshot 2024-03-28 at 23 18 20" src="https://github.com/sek-consulting/solid-ui/assets/604053/f9e71df5-da74-4aae-a707-be7f756e088a">

### **Fixed:**
<img width="429" alt="Screenshot 2024-03-28 at 23 16 40" src="https://github.com/sek-consulting/solid-ui/assets/604053/0c4143ba-f024-4fbd-b213-9979e20ee66a">
