### PR TITLE
fix(docs): overflow fixes for mobile

### DIFF
--- a/apps/docs/src/registry/example/badge-delta-demo.tsx
+++ b/apps/docs/src/registry/example/badge-delta-demo.tsx
@@ -4,7 +4,7 @@ export default function BadgeDeltaDemo() {
   return (
     <div class="flex flex-col gap-4">
       <p>BadgeDelta with pre-defined status icons</p>
-      <div class="flex gap-2">
+      <div class="flex flex-wrap gap-2">
         <BadgeDelta deltaType="increase">text</BadgeDelta>
         <BadgeDelta deltaType="moderateIncrease">text</BadgeDelta>
         <BadgeDelta deltaType="unchanged">text</BadgeDelta>
@@ -12,7 +12,7 @@ export default function BadgeDeltaDemo() {
         <BadgeDelta deltaType="decrease">text</BadgeDelta>
       </div>
       <p>BadgeDelta without text</p>
-      <div class="flex gap-2">
+      <div class="flex flex-wrap gap-2">
         <BadgeDelta deltaType="increase" />
         <BadgeDelta deltaType="moderateIncrease" />
         <BadgeDelta deltaType="unchanged" />

--- a/apps/docs/src/registry/example/delta-bar-demo.tsx
+++ b/apps/docs/src/registry/example/delta-bar-demo.tsx
@@ -2,7 +2,7 @@ import { DeltaBar } from "~/registry/ui/delta-bar"
 
 export default function DeltaBarDemo() {
   return (
-    <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-4 overflow-x-scroll">
       <p>DeltaBar with default increase behavior</p>
       <DeltaBar value={60} class="w-[400px]" />
       <p>DeltaBar with increase seen as negative</p>

--- a/apps/docs/src/registry/example/toast-demo.tsx
+++ b/apps/docs/src/registry/example/toast-demo.tsx
@@ -3,7 +3,7 @@ import { showToast, Toaster } from "~/registry/ui/toast"
 
 export default function ToastDemo() {
   return (
-    <div class="flex gap-2">
+    <div class="flex flex-wrap gap-2">
       <Button
         onClick={() =>
           showToast({


### PR DESCRIPTION
A few of the demo components have overflow issues on mobile. This fixes that.

before:

![image](https://github.com/sek-consulting/solid-ui/assets/7157288/8513a18e-1ec8-4d58-8e43-422e8d848f93)


after:

![image](https://github.com/sek-consulting/solid-ui/assets/7157288/038c1f9b-a7a8-400c-ae7b-1eb8b1f66f34)

before:

![image](https://github.com/sek-consulting/solid-ui/assets/7157288/10d3d0f8-fb56-4d59-ae92-021e898b9cc2)


after:

![image](https://github.com/sek-consulting/solid-ui/assets/7157288/5e42dd51-549c-4181-8580-9926d33befee)


before:

![image](https://github.com/sek-consulting/solid-ui/assets/7157288/35d6ef31-dce8-4f51-a6a4-819f79bbbb9c)

after:

![image](https://github.com/sek-consulting/solid-ui/assets/7157288/ca3d75b5-2492-451b-9ba0-b1a8be01bac0)

