### PR TITLE
Improve package manager detection using @antfu/ni

### DIFF
--- a/.changeset/tall-pans-drive.md
+++ b/.changeset/tall-pans-drive.md
@@ -1,0 +1,5 @@
+---
+"solidui-cli": patch
+---
+
+Improve package manager detection using @antfu/ni

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "pub:release": "pnpm build && pnpm publish --access public"
   },
   "dependencies": {
+    "@antfu/ni": "^0.21.12",
     "@babel/core": "^7.22.20",
     "@babel/parser": "^7.22.16",
     "@babel/plugin-transform-typescript": "^7.22.15",
@@ -48,7 +49,6 @@
     "@types/babel__core": "^7.20.2",
     "chalk": "^5.3.0",
     "commander": "^11.0.0",
-    "detect-package-manager": "^3.0.1",
     "json5": "^2.2.3",
     "prompts": "^2.4.2",
     "recast": "^0.23.4",

--- a/packages/cli/src/lib/utils.ts
+++ b/packages/cli/src/lib/utils.ts
@@ -1,8 +1,8 @@
 import { execSync } from "child_process"
 import { readFile } from "fs"
 
+import { detect } from "@antfu/ni"
 import { log, spinner } from "@clack/prompts"
-import { detect } from "detect-package-manager"
 import JSON5 from "json5"
 
 export function readJsonFile(
@@ -44,11 +44,14 @@ export function removeExtension(value: string) {
 }
 
 export async function installPackages(...packages: string[]) {
-  const packageManager = await detect()
+  const packageManager = await detect({ programmatic: true })
 
   switch (packageManager) {
-    case "yarn":
+    case "bun":
     case "pnpm":
+    case "pnpm@6":
+    case "yarn":
+    case "yarn@berry":
       runCommand(`${packageManager} add ${packages.join(" ")}`, "Installing dependencies")
       break
     default:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@antfu/ni':
+        specifier: ^0.21.12
+        version: 0.21.12
       '@babel/core':
         specifier: ^7.22.20
         version: 7.23.0
@@ -202,9 +205,6 @@ importers:
       commander:
         specifier: ^11.0.0
         version: 11.0.0
-      detect-package-manager:
-        specifier: ^3.0.1
-        version: 3.0.1
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -226,7 +226,7 @@ importers:
         version: 2.4.5
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.38)(typescript@5.1.6)
+        version: 7.2.0(typescript@5.1.6)
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -247,6 +247,11 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+
+  /@antfu/ni@0.21.12:
+    resolution: {integrity: sha512-2aDL3WUv8hMJb2L3r/PIQWsTLyq7RQr3v9xD16fiz6O8ys1xEyLhhTOv8gxtZvJiTzjTF5pHoArvRdesGL1DMQ==}
+    hasBin: true
+    dev: false
 
   /@antfu/utils@0.7.5:
     resolution: {integrity: sha512-dlR6LdS+0SzOAPx/TPRhnoi7hE251OVeT2Snw0RguNbBSbjUHdWr0l3vcUUDg26rEysT89kCbtw1lVorBXLLCg==}
@@ -4125,13 +4130,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /detect-package-manager@3.0.1:
-    resolution: {integrity: sha512-qoHDH6+lMcpJPAScE7+5CYj91W0mxZNXTwZPrCqi1KMk+x+AoQScQ2V1QyqTln1rHU5Haq5fikvOGHv+leKD8A==}
-    engines: {node: '>=12'}
-    dependencies:
-      execa: 5.1.1
-    dev: false
-
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -7129,6 +7127,22 @@ packages:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
+  /postcss-load-config@4.0.1:
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 2.4.1
+    dev: true
+
   /postcss-load-config@4.0.1(postcss@8.4.38):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -8336,7 +8350,7 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
-  /tsup@7.2.0(postcss@8.4.38)(typescript@5.1.6):
+  /tsup@7.2.0(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -8360,8 +8374,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss: 8.4.38
-      postcss-load-config: 4.0.1(postcss@8.4.38)
+      postcss-load-config: 4.0.1
       resolve-from: 5.0.0
       rollup: 3.27.2
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
Following my [comment](https://github.com/sek-consulting/solid-ui/issues/38#issuecomment-2089281970) on #38, I took the liberty of implementing the change from `detect-package-manager` to `@antfu/ni`.

This should improve the package manager detection allowing for more flexible use cases like my setup in a monorepo with bun.

Tested it on my repository after a `build` and it worked without the need for workarounds.
My setup is simple and I've not tested other use cases, would appreciate any help if you find it is necessary to test more.

I found the changes to be small and I don't expect much to break, but in any case I'm willing to help solve any side effects.

I've ensured to use pnpm@8 (from brew) so the `pnpm-lock.yaml` wouldn't change too much, but I suggest upgrading pnpm as pnpm@8 is already marked for deprecation (maybe I'll try another PR for it).

maybe this will resolve #38, but as my approach was focused on another use case I'm submitting the PR without automatic closing for it.