### PR TITLE
fix: hydration issue in drawer-dialog example

### DIFF
--- a/.changeset/chatty-steaks-lie.md
+++ b/.changeset/chatty-steaks-lie.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+fix hydration issue in drawer-dialog example

--- a/apps/docs/src/registry/example/drawer-dialog.tsx
+++ b/apps/docs/src/registry/example/drawer-dialog.tsx
@@ -1,6 +1,5 @@
 import type { ComponentProps } from "solid-js"
-import { createSignal, Show } from "solid-js"
-import { isServer } from "solid-js/web"
+import { createSignal, onMount, Show } from "solid-js"
 
 import { cn } from "~/lib/utils"
 import { Button } from "~/registry/ui/button"
@@ -27,13 +26,13 @@ import { Label } from "~/registry/ui/label"
 
 export default function DrawerDialogDemo() {
   const [open, setOpen] = createSignal(false)
+  const [isDesktop, setIsDesktop] = createSignal(false)
 
-  let isDesktop = true
-  if (!isServer) {
-    isDesktop = window.innerWidth >= 768
-  }
+  onMount(() => {
+    setIsDesktop(window.innerWidth >= 768)
+  })
 
-  const MobileDialog = (
+  const MobileDialog = () => (
     <Drawer open={open()} onOpenChange={setOpen}>
       <DrawerTrigger as={Button<"button">} variant="outline">
         Edit Profile
@@ -56,7 +55,7 @@ export default function DrawerDialogDemo() {
   )
 
   return (
-    <Show when={isDesktop} fallback={MobileDialog}>
+    <Show when={isDesktop()} fallback={<MobileDialog />}>
       <Dialog open={open()} onOpenChange={setOpen}>
         <DialogTrigger as={Button} variant="outline">
           Edit Profile


### PR DESCRIPTION
This PR fixes the "Responsive Dialog" example. The code caused hydration mismatches because we ran stuff dependent on `isServer` inside the component function. This moves the `innerWidth` check in an effect which fixes it. The example isn't responsive, meaning if the user resizes the browser it doesn't change what component to render. I can change this if you prefer it to be responsive, but I think for this example it's fine.