### PR TITLE
chore: update dependecy to `@kobalte/core@0.13.2`

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,7 +15,7 @@
     "@corvu/drawer": "^0.2.0",
     "@corvu/resizable": "^0.2.0",
     "@fontsource/inter": "^5.0.18",
-    "@kobalte/core": "0.13.0",
+    "@kobalte/core": "0.13.2",
     "@mdx-js/mdx": "^2.3.0",
     "@modular-forms/solid": "^0.20.0",
     "@solid-primitives/keyboard": "^1.2.8",

--- a/apps/docs/src/registry/ui/accordion.tsx
+++ b/apps/docs/src/registry/ui/accordion.tsx
@@ -7,24 +7,24 @@ import { cn } from "~/lib/utils"
 
 const Accordion = AccordionPrimitive.Root
 
-type AccordionItemProps = AccordionPrimitive.AccordionItemProps & {
+type AccordionItemProps<T extends ValidComponent = "div"> = AccordionPrimitive.AccordionItemProps<T> & {
   class?: string | undefined
 }
 
 const AccordionItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, AccordionItemProps>
+  props: PolymorphicProps<T, AccordionItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as AccordionItemProps, ["class"])
   return <AccordionPrimitive.Item class={cn("border-b", local.class)} {...others} />
 }
 
-type AccordionTriggerProps = AccordionPrimitive.AccordionTriggerProps & {
+type AccordionTriggerProps<T extends ValidComponent = "button"> = AccordionPrimitive.AccordionTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const AccordionTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, AccordionTriggerProps>
+  props: PolymorphicProps<T, AccordionTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as AccordionTriggerProps, ["class", "children"])
   return (
@@ -54,13 +54,13 @@ const AccordionTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type AccordionContentProps = AccordionPrimitive.AccordionContentProps & {
+type AccordionContentProps<T extends ValidComponent = "div"> = AccordionPrimitive.AccordionContentProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const AccordionContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, AccordionContentProps>
+  props: PolymorphicProps<T, AccordionContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as AccordionContentProps, ["class", "children"])
   return (

--- a/apps/docs/src/registry/ui/alert-dialog.tsx
+++ b/apps/docs/src/registry/ui/alert-dialog.tsx
@@ -9,12 +9,12 @@ const AlertDialog = AlertDialogPrimitive.Root
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger
 const AlertDialogPortal = AlertDialogPrimitive.Portal
 
-type AlertDialogOverlayProps = AlertDialogPrimitive.AlertDialogOverlayProps & {
+type AlertDialogOverlayProps<T extends ValidComponent = "div"> = AlertDialogPrimitive.AlertDialogOverlayProps<T> & {
   class?: string | undefined
 }
 
 const AlertDialogOverlay = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, AlertDialogOverlayProps>
+  props: PolymorphicProps<T, AlertDialogOverlayProps<T>>
 ) => {
   const [local, others] = splitProps(props as AlertDialogOverlayProps, ["class"])
   return (
@@ -28,13 +28,13 @@ const AlertDialogOverlay = <T extends ValidComponent = "div">(
   )
 }
 
-type AlertDialogContentProps = AlertDialogPrimitive.AlertDialogContentProps & {
+type AlertDialogContentProps<T extends ValidComponent = "div"> = AlertDialogPrimitive.AlertDialogContentProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const AlertDialogContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, AlertDialogContentProps>
+  props: PolymorphicProps<T, AlertDialogContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as AlertDialogContentProps, ["class", "children"])
   return (
@@ -69,23 +69,23 @@ const AlertDialogContent = <T extends ValidComponent = "div">(
   )
 }
 
-type AlertDialogTitleProps = AlertDialogPrimitive.AlertDialogTitleProps & {
+type AlertDialogTitleProps<T extends ValidComponent = "h2"> = AlertDialogPrimitive.AlertDialogTitleProps<T> & {
   class?: string | undefined
 }
 
 const AlertDialogTitle = <T extends ValidComponent = "h2">(
-  props: PolymorphicProps<T, AlertDialogTitleProps>
+  props: PolymorphicProps<T, AlertDialogTitleProps<T>>
 ) => {
   const [local, others] = splitProps(props as AlertDialogTitleProps, ["class"])
   return <AlertDialogPrimitive.Title class={cn("text-lg font-semibold", local.class)} {...others} />
 }
 
-type AlertDialogDescriptionProps = AlertDialogPrimitive.AlertDialogDescriptionProps & {
+type AlertDialogDescriptionProps<T extends ValidComponent = "p"> = AlertDialogPrimitive.AlertDialogDescriptionProps<T> & {
   class?: string | undefined
 }
 
 const AlertDialogDescription = <T extends ValidComponent = "p">(
-  props: PolymorphicProps<T, AlertDialogDescriptionProps>
+  props: PolymorphicProps<T, AlertDialogDescriptionProps<T>>
 ) => {
   const [local, others] = splitProps(props as AlertDialogDescriptionProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/alert.tsx
+++ b/apps/docs/src/registry/ui/alert.tsx
@@ -24,10 +24,10 @@ const alertVariants = cva(
   }
 )
 
-type AlertRootProps = AlertPrimitive.AlertRootProps &
+type AlertRootProps<T extends ValidComponent = "div"> = AlertPrimitive.AlertRootProps<T> &
   VariantProps<typeof alertVariants> & { class?: string | undefined }
 
-const Alert = <T extends ValidComponent = "div">(props: PolymorphicProps<T, AlertRootProps>) => {
+const Alert = <T extends ValidComponent = "div">(props: PolymorphicProps<T, AlertRootProps<T>>) => {
   const [local, others] = splitProps(props as AlertRootProps, ["class", "variant"])
   return (
     <AlertPrimitive.Root

--- a/apps/docs/src/registry/ui/avatar.tsx
+++ b/apps/docs/src/registry/ui/avatar.tsx
@@ -5,9 +5,9 @@ import { PolymorphicProps } from "@kobalte/core/polymorphic"
 
 import { cn } from "~/lib/utils"
 
-type AvatarRootProps = ImagePrimitive.ImageRootProps & { class?: string | undefined }
+type AvatarRootProps<T extends ValidComponent = "span"> = ImagePrimitive.ImageRootProps<T> & { class?: string | undefined }
 
-const Avatar = <T extends ValidComponent = "span">(props: PolymorphicProps<T, AvatarRootProps>) => {
+const Avatar = <T extends ValidComponent = "span">(props: PolymorphicProps<T, AvatarRootProps<T>>) => {
   const [local, others] = splitProps(props as AvatarRootProps, ["class"])
   return (
     <ImagePrimitive.Root
@@ -17,19 +17,19 @@ const Avatar = <T extends ValidComponent = "span">(props: PolymorphicProps<T, Av
   )
 }
 
-type AvatarImageProps = ImagePrimitive.ImageImgProps & { class?: string | undefined }
+type AvatarImageProps<T extends ValidComponent = "img"> = ImagePrimitive.ImageImgProps<T> & { class?: string | undefined }
 
 const AvatarImage = <T extends ValidComponent = "img">(
-  props: PolymorphicProps<T, AvatarImageProps>
+  props: PolymorphicProps<T, AvatarImageProps<T>>
 ) => {
   const [local, others] = splitProps(props as AvatarImageProps, ["class"])
   return <ImagePrimitive.Img class={cn("aspect-square size-full", local.class)} {...others} />
 }
 
-type AvatarFallbackProps = ImagePrimitive.ImageFallbackProps & { class?: string | undefined }
+type AvatarFallbackProps<T extends ValidComponent = "span"> = ImagePrimitive.ImageFallbackProps<T> & { class?: string | undefined }
 
 const AvatarFallback = <T extends ValidComponent = "span">(
-  props: PolymorphicProps<T, AvatarFallbackProps>
+  props: PolymorphicProps<T, AvatarFallbackProps<T>>
 ) => {
   const [local, others] = splitProps(props as AvatarFallbackProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/button.tsx
+++ b/apps/docs/src/registry/ui/button.tsx
@@ -33,10 +33,10 @@ const buttonVariants = cva(
   }
 )
 
-type ButtonProps = ButtonPrimitive.ButtonRootProps &
+type ButtonProps<T extends ValidComponent = "button"> = ButtonPrimitive.ButtonRootProps<T> &
   VariantProps<typeof buttonVariants> & { class?: string | undefined; children?: JSX.Element }
 
-const Button = <T extends ValidComponent = "button">(props: PolymorphicProps<T, ButtonProps>) => {
+const Button = <T extends ValidComponent = "button">(props: PolymorphicProps<T, ButtonProps<T>>) => {
   const [local, others] = splitProps(props as ButtonProps, ["variant", "size", "class"])
   return (
     <ButtonPrimitive.Root

--- a/apps/docs/src/registry/ui/checkbox.tsx
+++ b/apps/docs/src/registry/ui/checkbox.tsx
@@ -5,10 +5,10 @@ import { PolymorphicProps } from "@kobalte/core/polymorphic"
 
 import { cn } from "~/lib/utils"
 
-type CheckboxRootProps = CheckboxPrimitive.CheckboxRootProps & { class?: string | undefined }
+type CheckboxRootProps<T extends ValidComponent = "div"> = CheckboxPrimitive.CheckboxRootProps<T> & { class?: string | undefined }
 
 const Checkbox = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, CheckboxRootProps>
+  props: PolymorphicProps<T, CheckboxRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as CheckboxRootProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/combobox.tsx
+++ b/apps/docs/src/registry/ui/combobox.tsx
@@ -9,10 +9,10 @@ const Combobox = ComboboxPrimitive.Root
 const ComboboxItemLabel = ComboboxPrimitive.ItemLabel
 const ComboboxHiddenSelect = ComboboxPrimitive.HiddenSelect
 
-type ComboboxItemProps = ComboboxPrimitive.ComboboxItemProps & { class?: string | undefined }
+type ComboboxItemProps<T extends ValidComponent = "li"> = ComboboxPrimitive.ComboboxItemProps<T> & { class?: string | undefined }
 
 const ComboboxItem = <T extends ValidComponent = "li">(
-  props: PolymorphicProps<T, ComboboxItemProps>
+  props: PolymorphicProps<T, ComboboxItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as ComboboxItemProps, ["class"])
   return (
@@ -26,12 +26,12 @@ const ComboboxItem = <T extends ValidComponent = "li">(
   )
 }
 
-type ComboboxItemIndicatorProps = ComboboxPrimitive.ComboboxItemIndicatorProps & {
+type ComboboxItemIndicatorProps<T extends ValidComponent = "div"> = ComboboxPrimitive.ComboboxItemIndicatorProps<T> & {
   children?: JSX.Element
 }
 
 const ComboboxItemIndicator = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ComboboxItemIndicatorProps>
+  props: PolymorphicProps<T, ComboboxItemIndicatorProps<T>>
 ) => {
   const [local, others] = splitProps(props as ComboboxItemIndicatorProps, ["children"])
   return (
@@ -54,10 +54,10 @@ const ComboboxItemIndicator = <T extends ValidComponent = "div">(
   )
 }
 
-type ComboboxSectionProps = ComboboxPrimitive.ComboboxSectionProps & { class?: string | undefined }
+type ComboboxSectionProps<T extends ValidComponent = "li"> = ComboboxPrimitive.ComboboxSectionProps<T> & { class?: string | undefined }
 
 const ComboboxSection = <T extends ValidComponent = "li">(
-  props: PolymorphicProps<T, ComboboxSectionProps>
+  props: PolymorphicProps<T, ComboboxSectionProps<T>>
 ) => {
   const [local, others] = splitProps(props as ComboboxSectionProps, ["class"])
   return (
@@ -71,7 +71,7 @@ const ComboboxSection = <T extends ValidComponent = "li">(
   )
 }
 
-type ComboboxControlProps<U> = ComboboxPrimitive.ComboboxControlProps<U> & {
+type ComboboxControlProps<U, T extends ValidComponent = "div"> = ComboboxPrimitive.ComboboxControlProps<U, T> & {
   class?: string | undefined
 }
 
@@ -87,10 +87,10 @@ const ComboboxControl = <T, U extends ValidComponent = "div">(
   )
 }
 
-type ComboboxInputProps = ComboboxPrimitive.ComboboxInputProps & { class?: string | undefined }
+type ComboboxInputProps<T extends ValidComponent = "input"> = ComboboxPrimitive.ComboboxInputProps<T> & { class?: string | undefined }
 
 const ComboboxInput = <T extends ValidComponent = "input">(
-  props: PolymorphicProps<T, ComboboxInputProps>
+  props: PolymorphicProps<T, ComboboxInputProps<T>>
 ) => {
   const [local, others] = splitProps(props as ComboboxInputProps, ["class"])
   return (
@@ -104,13 +104,13 @@ const ComboboxInput = <T extends ValidComponent = "input">(
   )
 }
 
-type ComboboxTriggerProps = ComboboxPrimitive.ComboboxTriggerProps & {
+type ComboboxTriggerProps<T extends ValidComponent = "button"> = ComboboxPrimitive.ComboboxTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const ComboboxTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, ComboboxTriggerProps>
+  props: PolymorphicProps<T, ComboboxTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as ComboboxTriggerProps, ["class", "children"])
   return (
@@ -136,10 +136,10 @@ const ComboboxTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type ComboboxContentProps = ComboboxPrimitive.ComboboxContentProps & { class?: string | undefined }
+type ComboboxContentProps<T extends ValidComponent = "div"> = ComboboxPrimitive.ComboboxContentProps<T> & { class?: string | undefined }
 
 const ComboboxContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ComboboxContentProps>
+  props: PolymorphicProps<T, ComboboxContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as ComboboxContentProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/context-menu.tsx
+++ b/apps/docs/src/registry/ui/context-menu.tsx
@@ -16,12 +16,12 @@ const ContextMenu: Component<ContextMenuPrimitive.ContextMenuRootProps> = (props
   return <ContextMenuPrimitive.Root gutter={4} {...props} />
 }
 
-type ContextMenuContentProps = ContextMenuPrimitive.ContextMenuContentProps & {
+type ContextMenuContentProps<T extends ValidComponent = "div"> = ContextMenuPrimitive.ContextMenuContentProps<T> & {
   class?: string | undefined
 }
 
 const ContextMenuContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ContextMenuContentProps>
+  props: PolymorphicProps<T, ContextMenuContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuContentProps, ["class"])
   return (
@@ -37,12 +37,12 @@ const ContextMenuContent = <T extends ValidComponent = "div">(
   )
 }
 
-type ContextMenuItemProps = ContextMenuPrimitive.ContextMenuItemProps & {
+type ContextMenuItemProps<T extends ValidComponent = "div"> = ContextMenuPrimitive.ContextMenuItemProps<T> & {
   class?: string | undefined
 }
 
 const ContextMenuItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ContextMenuItemProps>
+  props: PolymorphicProps<T, ContextMenuItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuItemProps, ["class"])
   return (
@@ -61,12 +61,12 @@ const ContextMenuShortcut: Component<ComponentProps<"span">> = (props) => {
   return <span class={cn("ml-auto text-xs tracking-widest opacity-60", local.class)} {...others} />
 }
 
-type ContextMenuSeparatorProps = ContextMenuPrimitive.ContextMenuSeparatorProps & {
+type ContextMenuSeparatorProps<T extends ValidComponent = "hr"> = ContextMenuPrimitive.ContextMenuSeparatorProps<T> & {
   class?: string | undefined
 }
 
 const ContextMenuSeparator = <T extends ValidComponent = "hr">(
-  props: PolymorphicProps<T, ContextMenuSeparatorProps>
+  props: PolymorphicProps<T, ContextMenuSeparatorProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuSeparatorProps, ["class"])
   return (
@@ -77,13 +77,13 @@ const ContextMenuSeparator = <T extends ValidComponent = "hr">(
   )
 }
 
-type ContextMenuSubTriggerProps = ContextMenuPrimitive.ContextMenuSubTriggerProps & {
+type ContextMenuSubTriggerProps<T extends ValidComponent = "div"> = ContextMenuPrimitive.ContextMenuSubTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const ContextMenuSubTrigger = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ContextMenuSubTriggerProps>
+  props: PolymorphicProps<T, ContextMenuSubTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuSubTriggerProps, ["class", "children"])
   return (
@@ -111,12 +111,12 @@ const ContextMenuSubTrigger = <T extends ValidComponent = "div">(
   )
 }
 
-type ContextMenuSubContentProps = ContextMenuPrimitive.ContextMenuSubContentProps & {
+type ContextMenuSubContentProps<T extends ValidComponent = "div"> = ContextMenuPrimitive.ContextMenuSubContentProps<T> & {
   class?: string | undefined
 }
 
 const ContextMenuSubContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ContextMenuSubContentProps>
+  props: PolymorphicProps<T, ContextMenuSubContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuSubContentProps, ["class"])
   return (
@@ -130,13 +130,13 @@ const ContextMenuSubContent = <T extends ValidComponent = "div">(
   )
 }
 
-type ContextMenuCheckboxItemProps = ContextMenuPrimitive.ContextMenuCheckboxItemProps & {
+type ContextMenuCheckboxItemProps<T extends ValidComponent = "div"> = ContextMenuPrimitive.ContextMenuCheckboxItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const ContextMenuCheckboxItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ContextMenuCheckboxItemProps>
+  props: PolymorphicProps<T, ContextMenuCheckboxItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuCheckboxItemProps, ["class", "children"])
   return (
@@ -168,12 +168,12 @@ const ContextMenuCheckboxItem = <T extends ValidComponent = "div">(
   )
 }
 
-type ContextMenuGroupLabelProps = ContextMenuPrimitive.ContextMenuGroupLabelProps & {
+type ContextMenuGroupLabelProps<T extends ValidComponent = "span"> = ContextMenuPrimitive.ContextMenuGroupLabelProps<T> & {
   class?: string | undefined
 }
 
 const ContextMenuGroupLabel = <T extends ValidComponent = "span">(
-  props: PolymorphicProps<T, ContextMenuGroupLabelProps>
+  props: PolymorphicProps<T, ContextMenuGroupLabelProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuGroupLabelProps, ["class"])
   return (
@@ -184,13 +184,13 @@ const ContextMenuGroupLabel = <T extends ValidComponent = "span">(
   )
 }
 
-type ContextMenuRadioItemProps = ContextMenuPrimitive.ContextMenuRadioItemProps & {
+type ContextMenuRadioItemProps<T extends ValidComponent = "div"> = ContextMenuPrimitive.ContextMenuRadioItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const ContextMenuRadioItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ContextMenuRadioItemProps>
+  props: PolymorphicProps<T, ContextMenuRadioItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as ContextMenuRadioItemProps, ["class", "children"])
   return (

--- a/apps/docs/src/registry/ui/dialog.tsx
+++ b/apps/docs/src/registry/ui/dialog.tsx
@@ -20,10 +20,10 @@ const DialogPortal: Component<DialogPrimitive.DialogPortalProps> = (props) => {
   )
 }
 
-type DialogOverlayProps = DialogPrimitive.DialogOverlayProps & { class?: string | undefined }
+type DialogOverlayProps<T extends ValidComponent = "div"> = DialogPrimitive.DialogOverlayProps<T> & { class?: string | undefined }
 
 const DialogOverlay = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DialogOverlayProps>
+  props: PolymorphicProps<T, DialogOverlayProps<T>>
 ) => {
   const [, rest] = splitProps(props as DialogOverlayProps, ["class"])
   return (
@@ -37,13 +37,13 @@ const DialogOverlay = <T extends ValidComponent = "div">(
   )
 }
 
-type DialogContentProps = DialogPrimitive.DialogContentProps & {
+type DialogContentProps<T extends ValidComponent = "div"> = DialogPrimitive.DialogContentProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const DialogContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DialogContentProps>
+  props: PolymorphicProps<T, DialogContentProps<T>>
 ) => {
   const [, rest] = splitProps(props as DialogContentProps, ["class", "children"])
   return (
@@ -95,10 +95,10 @@ const DialogFooter: Component<ComponentProps<"div">> = (props) => {
   )
 }
 
-type DialogTitleProps = DialogPrimitive.DialogTitleProps & { class?: string | undefined }
+type DialogTitleProps<T extends ValidComponent = "h2"> = DialogPrimitive.DialogTitleProps<T> & { class?: string | undefined }
 
 const DialogTitle = <T extends ValidComponent = "h2">(
-  props: PolymorphicProps<T, DialogTitleProps>
+  props: PolymorphicProps<T, DialogTitleProps<T>>
 ) => {
   const [, rest] = splitProps(props as DialogTitleProps, ["class"])
   return (
@@ -109,12 +109,12 @@ const DialogTitle = <T extends ValidComponent = "h2">(
   )
 }
 
-type DialogDescriptionProps = DialogPrimitive.DialogDescriptionProps & {
+type DialogDescriptionProps<T extends ValidComponent = "p"> = DialogPrimitive.DialogDescriptionProps<T> & {
   class?: string | undefined
 }
 
 const DialogDescription = <T extends ValidComponent = "p">(
-  props: PolymorphicProps<T, DialogDescriptionProps>
+  props: PolymorphicProps<T, DialogDescriptionProps<T>>
 ) => {
   const [, rest] = splitProps(props as DialogDescriptionProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/dropdown-menu.tsx
+++ b/apps/docs/src/registry/ui/dropdown-menu.tsx
@@ -16,12 +16,12 @@ const DropdownMenu: Component<DropdownMenuPrimitive.DropdownMenuRootProps> = (pr
   return <DropdownMenuPrimitive.Root gutter={4} {...props} />
 }
 
-type DropdownMenuContentProps = DropdownMenuPrimitive.DropdownMenuContentProps & {
+type DropdownMenuContentProps<T extends ValidComponent = "div"> = DropdownMenuPrimitive.DropdownMenuContentProps<T> & {
   class?: string | undefined
 }
 
 const DropdownMenuContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DropdownMenuContentProps>
+  props: PolymorphicProps<T, DropdownMenuContentProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuContentProps, ["class"])
   return (
@@ -37,12 +37,12 @@ const DropdownMenuContent = <T extends ValidComponent = "div">(
   )
 }
 
-type DropdownMenuItemProps = DropdownMenuPrimitive.DropdownMenuItemProps & {
+type DropdownMenuItemProps<T extends ValidComponent = "div"> = DropdownMenuPrimitive.DropdownMenuItemProps<T> & {
   class?: string | undefined
 }
 
 const DropdownMenuItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DropdownMenuItemProps>
+  props: PolymorphicProps<T, DropdownMenuItemProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuItemProps, ["class"])
   return (
@@ -71,12 +71,12 @@ const DropdownMenuLabel: Component<ComponentProps<"div"> & { inset?: boolean }> 
   )
 }
 
-type DropdownMenuSeparatorProps = DropdownMenuPrimitive.DropdownMenuSeparatorProps & {
+type DropdownMenuSeparatorProps<T extends ValidComponent = "hr"> = DropdownMenuPrimitive.DropdownMenuSeparatorProps<T> & {
   class?: string | undefined
 }
 
 const DropdownMenuSeparator = <T extends ValidComponent = "hr">(
-  props: PolymorphicProps<T, DropdownMenuSeparatorProps>
+  props: PolymorphicProps<T, DropdownMenuSeparatorProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuSeparatorProps, ["class"])
   return (
@@ -87,13 +87,13 @@ const DropdownMenuSeparator = <T extends ValidComponent = "hr">(
   )
 }
 
-type DropdownMenuSubTriggerProps = DropdownMenuPrimitive.DropdownMenuSubTriggerProps & {
+type DropdownMenuSubTriggerProps<T extends ValidComponent = "div"> = DropdownMenuPrimitive.DropdownMenuSubTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const DropdownMenuSubTrigger = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DropdownMenuSubTriggerProps>
+  props: PolymorphicProps<T, DropdownMenuSubTriggerProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuSubTriggerProps, ["class", "children"])
   return (
@@ -121,12 +121,12 @@ const DropdownMenuSubTrigger = <T extends ValidComponent = "div">(
   )
 }
 
-type DropdownMenuSubContentProps = DropdownMenuPrimitive.DropdownMenuSubContentProps & {
+type DropdownMenuSubContentProps<T extends ValidComponent = "div"> = DropdownMenuPrimitive.DropdownMenuSubContentProps<T> & {
   class?: string | undefined
 }
 
 const DropdownMenuSubContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DropdownMenuSubContentProps>
+  props: PolymorphicProps<T, DropdownMenuSubContentProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuSubContentProps, ["class"])
   return (
@@ -140,13 +140,13 @@ const DropdownMenuSubContent = <T extends ValidComponent = "div">(
   )
 }
 
-type DropdownMenuCheckboxItemProps = DropdownMenuPrimitive.DropdownMenuCheckboxItemProps & {
+type DropdownMenuCheckboxItemProps<T extends ValidComponent = "div"> = DropdownMenuPrimitive.DropdownMenuCheckboxItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const DropdownMenuCheckboxItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DropdownMenuCheckboxItemProps>
+  props: PolymorphicProps<T, DropdownMenuCheckboxItemProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuCheckboxItemProps, ["class", "children"])
   return (
@@ -178,12 +178,12 @@ const DropdownMenuCheckboxItem = <T extends ValidComponent = "div">(
   )
 }
 
-type DropdownMenuGroupLabelProps = DropdownMenuPrimitive.DropdownMenuGroupLabelProps & {
+type DropdownMenuGroupLabelProps<T extends ValidComponent = "span"> = DropdownMenuPrimitive.DropdownMenuGroupLabelProps<T> & {
   class?: string | undefined
 }
 
 const DropdownMenuGroupLabel = <T extends ValidComponent = "span">(
-  props: PolymorphicProps<T, DropdownMenuGroupLabelProps>
+  props: PolymorphicProps<T, DropdownMenuGroupLabelProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuGroupLabelProps, ["class"])
   return (
@@ -194,13 +194,13 @@ const DropdownMenuGroupLabel = <T extends ValidComponent = "span">(
   )
 }
 
-type DropdownMenuRadioItemProps = DropdownMenuPrimitive.DropdownMenuRadioItemProps & {
+type DropdownMenuRadioItemProps<T extends ValidComponent = "div"> = DropdownMenuPrimitive.DropdownMenuRadioItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const DropdownMenuRadioItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DropdownMenuRadioItemProps>
+  props: PolymorphicProps<T, DropdownMenuRadioItemProps<T>>
 ) => {
   const [, rest] = splitProps(props as DropdownMenuRadioItemProps, ["class", "children"])
   return (

--- a/apps/docs/src/registry/ui/hover-card.tsx
+++ b/apps/docs/src/registry/ui/hover-card.tsx
@@ -12,12 +12,12 @@ const HoverCard: Component<HoverCardPrimitive.HoverCardRootProps> = (props) => {
   return <HoverCardPrimitive.Root gutter={4} {...props} />
 }
 
-type HoverCardContentProps = HoverCardPrimitive.HoverCardContentProps & {
+type HoverCardContentProps<T extends ValidComponent = "div"> = HoverCardPrimitive.HoverCardContentProps<T> & {
   class?: string | undefined
 }
 
 const HoverCardContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, HoverCardContentProps>
+  props: PolymorphicProps<T, HoverCardContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as HoverCardContentProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/menubar.tsx
+++ b/apps/docs/src/registry/ui/menubar.tsx
@@ -11,10 +11,10 @@ const MenubarPortal = MenubarPrimitive.Portal
 const MenubarSub = MenubarPrimitive.Sub
 const MenubarRadioGroup = MenubarPrimitive.RadioGroup
 
-type MenubarRootProps = MenubarPrimitive.MenubarRootProps & { class?: string | undefined }
+type MenubarRootProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarRootProps<T> & { class?: string | undefined }
 
 const Menubar = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarRootProps>
+  props: PolymorphicProps<T, MenubarRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarRootProps, ["class"])
   return (
@@ -32,10 +32,10 @@ const MenubarMenu: Component<MenubarPrimitive.MenubarMenuProps> = (props) => {
   return <MenubarPrimitive.Menu gutter={8} {...props} />
 }
 
-type MenubarTriggerProps = MenubarPrimitive.MenubarTriggerProps & { class?: string | undefined }
+type MenubarTriggerProps<T extends ValidComponent = "button"> = MenubarPrimitive.MenubarTriggerProps<T> & { class?: string | undefined }
 
 const MenubarTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, MenubarTriggerProps>
+  props: PolymorphicProps<T, MenubarTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarTriggerProps, ["class"])
   return (
@@ -49,10 +49,10 @@ const MenubarTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type MenubarContentProps = MenubarPrimitive.MenubarContentProps & { class?: string | undefined }
+type MenubarContentProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarContentProps<T> & { class?: string | undefined }
 
 const MenubarContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarContentProps>
+  props: PolymorphicProps<T, MenubarContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarContentProps, ["class"])
   return (
@@ -68,14 +68,14 @@ const MenubarContent = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarSubTriggerProps = MenubarPrimitive.MenubarSubTriggerProps & {
+type MenubarSubTriggerProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarSubTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
   inset?: boolean
 }
 
 const MenubarSubTrigger = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarSubTriggerProps>
+  props: PolymorphicProps<T, MenubarSubTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarSubTriggerProps, [
     "class",
@@ -108,12 +108,12 @@ const MenubarSubTrigger = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarSubContentProps = MenubarPrimitive.MenubarSubContentProps & {
+type MenubarSubContentProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarSubContentProps<T> & {
   class?: string | undefined
 }
 
 const MenubarSubContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarSubContentProps>
+  props: PolymorphicProps<T, MenubarSubContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarSubContentProps, ["class"])
   return (
@@ -129,13 +129,13 @@ const MenubarSubContent = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarItemProps = MenubarPrimitive.MenubarItemProps & {
+type MenubarItemProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarItemProps<T> & {
   class?: string | undefined
   inset?: boolean
 }
 
 const MenubarItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarItemProps>
+  props: PolymorphicProps<T, MenubarItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarItemProps, ["class", "inset"])
   return (
@@ -150,13 +150,13 @@ const MenubarItem = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarCheckboxItemProps = MenubarPrimitive.MenubarCheckboxItemProps & {
+type MenubarCheckboxItemProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarCheckboxItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const MenubarCheckboxItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarCheckboxItemProps>
+  props: PolymorphicProps<T, MenubarCheckboxItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarCheckboxItemProps, ["class", "children"])
   return (
@@ -188,13 +188,13 @@ const MenubarCheckboxItem = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarRadioItemProps = MenubarPrimitive.MenubarRadioItemProps & {
+type MenubarRadioItemProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarRadioItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const MenubarRadioItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarRadioItemProps>
+  props: PolymorphicProps<T, MenubarRadioItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarRadioItemProps, ["class", "children"])
   return (
@@ -226,13 +226,13 @@ const MenubarRadioItem = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarItemLabelProps = MenubarPrimitive.MenubarItemLabelProps & {
+type MenubarItemLabelProps<T extends ValidComponent = "div"> = MenubarPrimitive.MenubarItemLabelProps<T> & {
   class?: string | undefined
   inset?: boolean
 }
 
 const MenubarItemLabel = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, MenubarItemLabelProps>
+  props: PolymorphicProps<T, MenubarItemLabelProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarItemLabelProps, ["class", "inset"])
   return (
@@ -243,13 +243,13 @@ const MenubarItemLabel = <T extends ValidComponent = "div">(
   )
 }
 
-type MenubarGroupLabelProps = MenubarPrimitive.MenubarGroupLabelProps & {
+type MenubarGroupLabelProps<T extends ValidComponent = "span"> = MenubarPrimitive.MenubarGroupLabelProps<T> & {
   class?: string | undefined
   inset?: boolean
 }
 
 const MenubarGroupLabel = <T extends ValidComponent = "span">(
-  props: PolymorphicProps<T, MenubarGroupLabelProps>
+  props: PolymorphicProps<T, MenubarGroupLabelProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarGroupLabelProps, ["class", "inset"])
   return (
@@ -260,10 +260,10 @@ const MenubarGroupLabel = <T extends ValidComponent = "span">(
   )
 }
 
-type MenubarSeparatorProps = MenubarPrimitive.MenubarSeparatorProps & { class?: string | undefined }
+type MenubarSeparatorProps<T extends ValidComponent = "hr"> = MenubarPrimitive.MenubarSeparatorProps<T> & { class?: string | undefined }
 
 const MenubarSeparator = <T extends ValidComponent = "hr">(
-  props: PolymorphicProps<T, MenubarSeparatorProps>
+  props: PolymorphicProps<T, MenubarSeparatorProps<T>>
 ) => {
   const [local, others] = splitProps(props as MenubarSeparatorProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/number-field.tsx
+++ b/apps/docs/src/registry/ui/number-field.tsx
@@ -7,12 +7,12 @@ import { cn } from "~/lib/utils"
 
 const NumberField = NumberFieldPrimitive.Root
 
-type NumberFieldLabelProps = NumberFieldPrimitive.NumberFieldLabelProps & {
+type NumberFieldLabelProps<T extends ValidComponent = "label"> = NumberFieldPrimitive.NumberFieldLabelProps<T> & {
   class?: string | undefined
 }
 
 const NumberFieldLabel = <T extends ValidComponent = "label">(
-  props: PolymorphicProps<T, NumberFieldLabelProps>
+  props: PolymorphicProps<T, NumberFieldLabelProps<T>>
 ) => {
   const [local, others] = splitProps(props as NumberFieldLabelProps, ["class"])
   return (
@@ -26,12 +26,12 @@ const NumberFieldLabel = <T extends ValidComponent = "label">(
   )
 }
 
-type NumberFieldInputProps = NumberFieldPrimitive.NumberFieldInputProps & {
+type NumberFieldInputProps<T extends ValidComponent = "input"> = NumberFieldPrimitive.NumberFieldInputProps<T> & {
   class?: string | undefined
 }
 
 const NumberFieldInput = <T extends ValidComponent = "input">(
-  props: PolymorphicProps<T, NumberFieldInputProps>
+  props: PolymorphicProps<T, NumberFieldInputProps<T>>
 ) => {
   const [local, others] = splitProps(props as NumberFieldInputProps, ["class"])
   return (
@@ -45,13 +45,13 @@ const NumberFieldInput = <T extends ValidComponent = "input">(
   )
 }
 
-type NumberFieldIncrementTriggerProps = NumberFieldPrimitive.NumberFieldIncrementTriggerProps & {
+type NumberFieldIncrementTriggerProps<T extends ValidComponent = "button"> = NumberFieldPrimitive.NumberFieldIncrementTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const NumberFieldIncrementTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, NumberFieldIncrementTriggerProps>
+  props: PolymorphicProps<T, NumberFieldIncrementTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as NumberFieldIncrementTriggerProps, [
     "class",
@@ -83,13 +83,13 @@ const NumberFieldIncrementTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type NumberFieldDecrementTriggerProps = NumberFieldPrimitive.NumberFieldDecrementTriggerProps & {
+type NumberFieldDecrementTriggerProps<T extends ValidComponent = "button"> = NumberFieldPrimitive.NumberFieldDecrementTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const NumberFieldDecrementTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, NumberFieldDecrementTriggerProps>
+  props: PolymorphicProps<T, NumberFieldDecrementTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as NumberFieldDecrementTriggerProps, [
     "class",
@@ -121,12 +121,12 @@ const NumberFieldDecrementTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type NumberFieldDescriptionProps = NumberFieldPrimitive.NumberFieldDescriptionProps & {
+type NumberFieldDescriptionProps<T extends ValidComponent = "div"> = NumberFieldPrimitive.NumberFieldDescriptionProps<T> & {
   class?: string | undefined
 }
 
 const NumberFieldDescription = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, NumberFieldDescriptionProps>
+  props: PolymorphicProps<T, NumberFieldDescriptionProps<T>>
 ) => {
   const [local, others] = splitProps(props as NumberFieldDescriptionProps, ["class"])
   return (
@@ -137,12 +137,12 @@ const NumberFieldDescription = <T extends ValidComponent = "div">(
   )
 }
 
-type NumberFieldErrorMessageProps = NumberFieldPrimitive.NumberFieldErrorMessageProps & {
+type NumberFieldErrorMessageProps<T extends ValidComponent = "div"> = NumberFieldPrimitive.NumberFieldErrorMessageProps<T> & {
   class?: string | undefined
 }
 
 const NumberFieldErrorMessage = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, NumberFieldErrorMessageProps>
+  props: PolymorphicProps<T, NumberFieldErrorMessageProps<T>>
 ) => {
   const [local, others] = splitProps(props as NumberFieldErrorMessageProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/pagination.tsx
+++ b/apps/docs/src/registry/ui/pagination.tsx
@@ -9,10 +9,10 @@ import { buttonVariants } from "~/registry/ui/button"
 
 const PaginationItems = PaginationPrimitive.Items
 
-type PaginationRootProps = PaginationPrimitive.PaginationRootProps & { class?: string | undefined }
+type PaginationRootProps<T extends ValidComponent = "nav"> = PaginationPrimitive.PaginationRootProps<T> & { class?: string | undefined }
 
 const Pagination = <T extends ValidComponent = "nav">(
-  props: PolymorphicProps<T, PaginationRootProps>
+  props: PolymorphicProps<T, PaginationRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as PaginationRootProps, ["class"])
   return (
@@ -23,10 +23,10 @@ const Pagination = <T extends ValidComponent = "nav">(
   )
 }
 
-type PaginationItemProps = PaginationPrimitive.PaginationItemProps & { class?: string | undefined }
+type PaginationItemProps<T extends ValidComponent = "button"> = PaginationPrimitive.PaginationItemProps<T> & { class?: string | undefined }
 
 const PaginationItem = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, PaginationItemProps>
+  props: PolymorphicProps<T, PaginationItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as PaginationItemProps, ["class"])
   return (
@@ -43,12 +43,12 @@ const PaginationItem = <T extends ValidComponent = "button">(
   )
 }
 
-type PaginationEllipsisProps = PaginationPrimitive.PaginationEllipsisProps & {
+type PaginationEllipsisProps<T extends ValidComponent = "div"> = PaginationPrimitive.PaginationEllipsisProps<T> & {
   class?: string | undefined
 }
 
 const PaginationEllipsis = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, PaginationEllipsisProps>
+  props: PolymorphicProps<T, PaginationEllipsisProps<T>>
 ) => {
   const [local, others] = splitProps(props as PaginationEllipsisProps, ["class"])
   return (
@@ -75,12 +75,12 @@ const PaginationEllipsis = <T extends ValidComponent = "div">(
   )
 }
 
-type PaginationPreviousProps = PaginationPrimitive.PaginationPreviousProps & {
+type PaginationPreviousProps<T extends ValidComponent = "button"> = PaginationPrimitive.PaginationPreviousProps<T> & {
   class?: string | undefined
 }
 
 const PaginationPrevious = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, PaginationPreviousProps>
+  props: PolymorphicProps<T, PaginationPreviousProps<T>>
 ) => {
   const [local, others] = splitProps(props as PaginationPreviousProps, ["class"])
   return (
@@ -111,12 +111,12 @@ const PaginationPrevious = <T extends ValidComponent = "button">(
   )
 }
 
-type PaginationNextProps = PaginationPrimitive.PaginationNextProps & {
+type PaginationNextProps<T extends ValidComponent = "button"> = PaginationPrimitive.PaginationNextProps<T> & {
   class?: string | undefined
 }
 
 const PaginationNext = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, PaginationNextProps>
+  props: PolymorphicProps<T, PaginationNextProps<T>>
 ) => {
   const [local, others] = splitProps(props as PaginationNextProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/popover.tsx
+++ b/apps/docs/src/registry/ui/popover.tsx
@@ -12,10 +12,10 @@ const Popover: Component<PopoverPrimitive.PopoverRootProps> = (props) => {
   return <PopoverPrimitive.Root gutter={4} {...props} />
 }
 
-type PopoverContentProps = PopoverPrimitive.PopoverContentProps & { class?: string | undefined }
+type PopoverContentProps<T extends ValidComponent = "div"> = PopoverPrimitive.PopoverContentProps<T> & { class?: string | undefined }
 
 const PopoverContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, PopoverContentProps>
+  props: PolymorphicProps<T, PopoverContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as PopoverContentProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/progress.tsx
+++ b/apps/docs/src/registry/ui/progress.tsx
@@ -6,10 +6,10 @@ import * as ProgressPrimitive from "@kobalte/core/progress"
 
 import { Label } from "~/registry/ui/label"
 
-type ProgressRootProps = ProgressPrimitive.ProgressRootProps & { children?: JSX.Element }
+type ProgressRootProps<T extends ValidComponent = "div"> = ProgressPrimitive.ProgressRootProps<T> & { children?: JSX.Element }
 
 const Progress = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ProgressRootProps>
+  props: PolymorphicProps<T, ProgressRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as ProgressRootProps, ["children"])
   return (

--- a/apps/docs/src/registry/ui/radio-group.tsx
+++ b/apps/docs/src/registry/ui/radio-group.tsx
@@ -6,22 +6,22 @@ import * as RadioGroupPrimitive from "@kobalte/core/radio-group"
 
 import { cn } from "~/lib/utils"
 
-type RadioGroupRootProps = RadioGroupPrimitive.RadioGroupRootProps & { class?: string | undefined }
+type RadioGroupRootProps<T extends ValidComponent = "div"> = RadioGroupPrimitive.RadioGroupRootProps<T> & { class?: string | undefined }
 
 const RadioGroup = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, RadioGroupRootProps>
+  props: PolymorphicProps<T, RadioGroupRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as RadioGroupRootProps, ["class"])
   return <RadioGroupPrimitive.Root class={cn("grid gap-2", local.class)} {...others} />
 }
 
-type RadioGroupItemProps = RadioGroupPrimitive.RadioGroupItemProps & {
+type RadioGroupItemProps<T extends ValidComponent = "div"> = RadioGroupPrimitive.RadioGroupItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const RadioGroupItem = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, RadioGroupItemProps>
+  props: PolymorphicProps<T, RadioGroupItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as RadioGroupItemProps, ["class", "children"])
   return (
@@ -48,12 +48,12 @@ const RadioGroupItem = <T extends ValidComponent = "div">(
   )
 }
 
-type RadioGroupLabelProps = RadioGroupPrimitive.RadioGroupLabelProps & {
+type RadioGroupLabelProps<T extends ValidComponent = "label"> = RadioGroupPrimitive.RadioGroupLabelProps<T> & {
   class?: string | undefined
 }
 
 const RadioGroupItemLabel = <T extends ValidComponent = "label">(
-  props: PolymorphicProps<T, RadioGroupLabelProps>
+  props: PolymorphicProps<T, RadioGroupLabelProps<T>>
 ) => {
   const [local, others] = splitProps(props as RadioGroupLabelProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/select.tsx
+++ b/apps/docs/src/registry/ui/select.tsx
@@ -10,13 +10,13 @@ const Select = SelectPrimitive.Root
 const SelectValue = SelectPrimitive.Value
 const SelectHiddenSelect = SelectPrimitive.HiddenSelect
 
-type SelectTriggerProps = SelectPrimitive.SelectTriggerProps & {
+type SelectTriggerProps<T extends ValidComponent = "button"> = SelectPrimitive.SelectTriggerProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const SelectTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, SelectTriggerProps>
+  props: PolymorphicProps<T, SelectTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as SelectTriggerProps, ["class", "children"])
   return (
@@ -48,10 +48,10 @@ const SelectTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type SelectContentProps = SelectPrimitive.SelectContentProps & { class?: string | undefined }
+type SelectContentProps<T extends ValidComponent = "div"> = SelectPrimitive.SelectContentProps<T> & { class?: string | undefined }
 
 const SelectContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, SelectContentProps>
+  props: PolymorphicProps<T, SelectContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as SelectContentProps, ["class"])
   return (
@@ -69,13 +69,13 @@ const SelectContent = <T extends ValidComponent = "div">(
   )
 }
 
-type SelectItemProps = SelectPrimitive.SelectItemProps & {
+type SelectItemProps<T extends ValidComponent = "li"> = SelectPrimitive.SelectItemProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const SelectItem = <T extends ValidComponent = "li">(
-  props: PolymorphicProps<T, SelectItemProps>
+  props: PolymorphicProps<T, SelectItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as SelectItemProps, ["class", "children"])
   return (

--- a/apps/docs/src/registry/ui/separator.tsx
+++ b/apps/docs/src/registry/ui/separator.tsx
@@ -6,10 +6,10 @@ import * as SeparatorPrimitive from "@kobalte/core/separator"
 
 import { cn } from "~/lib/utils"
 
-type SeparatorRootProps = SeparatorPrimitive.SeparatorRootProps & { class?: string | undefined }
+type SeparatorRootProps<T extends ValidComponent = "hr"> = SeparatorPrimitive.SeparatorRootProps<T> & { class?: string | undefined }
 
 const Separator = <T extends ValidComponent = "hr">(
-  props: PolymorphicProps<T, SeparatorRootProps>
+  props: PolymorphicProps<T, SeparatorRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as SeparatorRootProps, ["class", "orientation"])
   return (

--- a/apps/docs/src/registry/ui/sheet.tsx
+++ b/apps/docs/src/registry/ui/sheet.tsx
@@ -34,10 +34,10 @@ const SheetPortal: Component<PortalProps> = (props) => {
   )
 }
 
-type DialogOverlayProps = SheetPrimitive.DialogOverlayProps & { class?: string | undefined }
+type DialogOverlayProps<T extends ValidComponent = "div"> = SheetPrimitive.DialogOverlayProps<T> & { class?: string | undefined }
 
 const SheetOverlay = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DialogOverlayProps>
+  props: PolymorphicProps<T, DialogOverlayProps<T>>
 ) => {
   const [local, others] = splitProps(props as DialogOverlayProps, ["class"])
   return (
@@ -70,11 +70,11 @@ const sheetVariants = cva(
   }
 )
 
-type DialogContentProps = SheetPrimitive.DialogContentProps &
+type DialogContentProps<T extends ValidComponent = "div"> = SheetPrimitive.DialogContentProps<T> &
   VariantProps<typeof sheetVariants> & { class?: string | undefined; children?: JSX.Element }
 
 const SheetContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, DialogContentProps>
+  props: PolymorphicProps<T, DialogContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as DialogContentProps, ["position", "class", "children"])
   return (
@@ -123,10 +123,10 @@ const SheetFooter: Component<ComponentProps<"div">> = (props) => {
   )
 }
 
-type DialogTitleProps = SheetPrimitive.DialogTitleProps & { class?: string | undefined }
+type DialogTitleProps<T extends ValidComponent = "h2"> = SheetPrimitive.DialogTitleProps<T> & { class?: string | undefined }
 
 const SheetTitle = <T extends ValidComponent = "h2">(
-  props: PolymorphicProps<T, DialogTitleProps>
+  props: PolymorphicProps<T, DialogTitleProps<T>>
 ) => {
   const [local, others] = splitProps(props as DialogTitleProps, ["class"])
   return (
@@ -137,10 +137,10 @@ const SheetTitle = <T extends ValidComponent = "h2">(
   )
 }
 
-type DialogDescriptionProps = SheetPrimitive.DialogDescriptionProps & { class?: string | undefined }
+type DialogDescriptionProps<T extends ValidComponent = "p"> = SheetPrimitive.DialogDescriptionProps<T> & { class?: string | undefined }
 
 const SheetDescription = <T extends ValidComponent = "p">(
-  props: PolymorphicProps<T, DialogDescriptionProps>
+  props: PolymorphicProps<T, DialogDescriptionProps<T>>
 ) => {
   const [local, others] = splitProps(props as DialogDescriptionProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/skeleton.tsx
+++ b/apps/docs/src/registry/ui/skeleton.tsx
@@ -6,10 +6,10 @@ import * as SkeletonPrimitive from "@kobalte/core/skeleton"
 
 import { cn } from "~/lib/utils"
 
-type SkeletonRootProps = SkeletonPrimitive.SkeletonRootProps & { class?: string | undefined }
+type SkeletonRootProps<T extends ValidComponent = "div"> = SkeletonPrimitive.SkeletonRootProps<T> & { class?: string | undefined }
 
 const Skeleton = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, SkeletonRootProps>
+  props: PolymorphicProps<T, SkeletonRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as SkeletonRootProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/slider.tsx
+++ b/apps/docs/src/registry/ui/slider.tsx
@@ -7,9 +7,9 @@ import * as SliderPrimitive from "@kobalte/core/slider"
 import { cn } from "~/lib/utils"
 import { Label } from "~/registry/ui/label"
 
-type SliderRootProps = SliderPrimitive.SliderRootProps & { class?: string | undefined }
+type SliderRootProps<T extends ValidComponent = "div"> = SliderPrimitive.SliderRootProps<T> & { class?: string | undefined }
 
-const Slider = <T extends ValidComponent = "div">(props: PolymorphicProps<T, SliderRootProps>) => {
+const Slider = <T extends ValidComponent = "div">(props: PolymorphicProps<T, SliderRootProps<T>>) => {
   const [local, others] = splitProps(props as SliderRootProps, ["class"])
   return (
     <SliderPrimitive.Root
@@ -19,10 +19,10 @@ const Slider = <T extends ValidComponent = "div">(props: PolymorphicProps<T, Sli
   )
 }
 
-type SliderTrackProps = SliderPrimitive.SliderTrackProps & { class?: string | undefined }
+type SliderTrackProps<T extends ValidComponent = "div"> = SliderPrimitive.SliderTrackProps<T> & { class?: string | undefined }
 
 const SliderTrack = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, SliderTrackProps>
+  props: PolymorphicProps<T, SliderTrackProps<T>>
 ) => {
   const [local, others] = splitProps(props as SliderTrackProps, ["class"])
   return (
@@ -33,22 +33,22 @@ const SliderTrack = <T extends ValidComponent = "div">(
   )
 }
 
-type SliderFillProps = SliderPrimitive.SliderFillProps & { class?: string | undefined }
+type SliderFillProps<T extends ValidComponent = "div"> = SliderPrimitive.SliderFillProps<T> & { class?: string | undefined }
 
 const SliderFill = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, SliderFillProps>
+  props: PolymorphicProps<T, SliderFillProps<T>>
 ) => {
   const [local, others] = splitProps(props as SliderFillProps, ["class"])
   return <SliderPrimitive.Fill class={cn("absolute h-full bg-primary", local.class)} {...others} />
 }
 
-type SliderThumbProps = SliderPrimitive.SliderThumbProps & {
+type SliderThumbProps<T extends ValidComponent = "span"> = SliderPrimitive.SliderThumbProps<T> & {
   class?: string | undefined
   children?: JSX.Element
 }
 
 const SliderThumb = <T extends ValidComponent = "span">(
-  props: PolymorphicProps<T, SliderThumbProps>
+  props: PolymorphicProps<T, SliderThumbProps<T>>
 ) => {
   const [local, others] = splitProps(props as SliderThumbProps, ["class", "children"])
   return (
@@ -65,13 +65,13 @@ const SliderThumb = <T extends ValidComponent = "span">(
 }
 
 const SliderLabel = <T extends ValidComponent = "label">(
-  props: PolymorphicProps<T, SliderPrimitive.SliderLabelProps>
+  props: PolymorphicProps<T, SliderPrimitive.SliderLabelProps<T>>
 ) => {
   return <SliderPrimitive.Label as={Label} {...props} />
 }
 
 const SliderValueLabel = <T extends ValidComponent = "label">(
-  props: PolymorphicProps<T, SliderPrimitive.SliderValueLabelProps>
+  props: PolymorphicProps<T, SliderPrimitive.SliderValueLabelProps<T>>
 ) => {
   return <SliderPrimitive.ValueLabel as={Label} {...props} />
 }

--- a/apps/docs/src/registry/ui/tabs.tsx
+++ b/apps/docs/src/registry/ui/tabs.tsx
@@ -8,9 +8,9 @@ import { cn } from "~/lib/utils"
 
 const Tabs = TabsPrimitive.Root
 
-type TabsListProps = TabsPrimitive.TabsListProps & { class?: string | undefined }
+type TabsListProps<T extends ValidComponent = "div"> = TabsPrimitive.TabsListProps<T> & { class?: string | undefined }
 
-const TabsList = <T extends ValidComponent = "div">(props: PolymorphicProps<T, TabsListProps>) => {
+const TabsList = <T extends ValidComponent = "div">(props: PolymorphicProps<T, TabsListProps<T>>) => {
   const [local, others] = splitProps(props as TabsListProps, ["class"])
   return (
     <TabsPrimitive.List
@@ -23,10 +23,10 @@ const TabsList = <T extends ValidComponent = "div">(props: PolymorphicProps<T, T
   )
 }
 
-type TabsTriggerProps = TabsPrimitive.TabsTriggerProps & { class?: string | undefined }
+type TabsTriggerProps<T extends ValidComponent = "button"> = TabsPrimitive.TabsTriggerProps<T> & { class?: string | undefined }
 
 const TabsTrigger = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, TabsTriggerProps>
+  props: PolymorphicProps<T, TabsTriggerProps<T>>
 ) => {
   const [local, others] = splitProps(props as TabsTriggerProps, ["class"])
   return (
@@ -40,10 +40,10 @@ const TabsTrigger = <T extends ValidComponent = "button">(
   )
 }
 
-type TabsContentProps = TabsPrimitive.TabsContentProps & { class?: string | undefined }
+type TabsContentProps<T extends ValidComponent = "div"> = TabsPrimitive.TabsContentProps<T> & { class?: string | undefined }
 
 const TabsContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, TabsContentProps>
+  props: PolymorphicProps<T, TabsContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as TabsContentProps, ["class"])
   return (
@@ -57,10 +57,10 @@ const TabsContent = <T extends ValidComponent = "div">(
   )
 }
 
-type TabsIndicatorProps = TabsPrimitive.TabsIndicatorProps & { class?: string | undefined }
+type TabsIndicatorProps<T extends ValidComponent = "div"> = TabsPrimitive.TabsIndicatorProps<T> & { class?: string | undefined }
 
 const TabsIndicator = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, TabsIndicatorProps>
+  props: PolymorphicProps<T, TabsIndicatorProps<T>>
 ) => {
   const [local, others] = splitProps(props as TabsIndicatorProps, ["class"])
   return (

--- a/apps/docs/src/registry/ui/toast.tsx
+++ b/apps/docs/src/registry/ui/toast.tsx
@@ -29,9 +29,9 @@ const toastVariants = cva(
 )
 type ToastVariant = NonNullable<VariantProps<typeof toastVariants>["variant"]>
 
-type ToastListProps = ToastPrimitive.ToastListProps & { class?: string | undefined }
+type ToastListProps<T extends ValidComponent = "ol"> = ToastPrimitive.ToastListProps<T> & { class?: string | undefined }
 
-const Toaster = <T extends ValidComponent = "ol">(props: PolymorphicProps<T, ToastListProps>) => {
+const Toaster = <T extends ValidComponent = "ol">(props: PolymorphicProps<T, ToastListProps<T>>) => {
   const [local, others] = splitProps(props as ToastListProps, ["class"])
   return (
     <Portal>
@@ -48,10 +48,10 @@ const Toaster = <T extends ValidComponent = "ol">(props: PolymorphicProps<T, Toa
   )
 }
 
-type ToastRootProps = ToastPrimitive.ToastRootProps &
+type ToastRootProps<T extends ValidComponent = "li"> = ToastPrimitive.ToastRootProps<T> &
   VariantProps<typeof toastVariants> & { class?: string | undefined }
 
-const Toast = <T extends ValidComponent = "li">(props: PolymorphicProps<T, ToastRootProps>) => {
+const Toast = <T extends ValidComponent = "li">(props: PolymorphicProps<T, ToastRootProps<T>>) => {
   const [local, others] = splitProps(props as ToastRootProps, ["class", "variant"])
   return (
     <ToastPrimitive.Root
@@ -61,12 +61,12 @@ const Toast = <T extends ValidComponent = "li">(props: PolymorphicProps<T, Toast
   )
 }
 
-type ToastCloseButtonProps = ToastPrimitive.ToastCloseButtonProps & { class?: string | undefined }
+type ToastCloseButtonProps<T extends ValidComponent = "button"> = ToastPrimitive.ToastCloseButtonProps<T> & { class?: string | undefined }
 
 const ToastClose = <T extends ValidComponent = "button">(
   props: PolymorphicProps<T, ToastCloseButtonProps>
 ) => {
-  const [local, others] = splitProps(props as ToastCloseButtonProps, ["class"])
+  const [local, others] = splitProps(props as ToastCloseButtonProps<T>, ["class"])
   return (
     <ToastPrimitive.CloseButton
       class={cn(
@@ -92,19 +92,19 @@ const ToastClose = <T extends ValidComponent = "button">(
   )
 }
 
-type ToastTitleProps = ToastPrimitive.ToastTitleProps & { class?: string | undefined }
+type ToastTitleProps<T extends ValidComponent = "div"> = ToastPrimitive.ToastTitleProps<T> & { class?: string | undefined }
 
 const ToastTitle = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ToastTitleProps>
+  props: PolymorphicProps<T, ToastTitleProps<T>>
 ) => {
   const [local, others] = splitProps(props as ToastTitleProps, ["class"])
   return <ToastPrimitive.Title class={cn("text-sm font-semibold", local.class)} {...others} />
 }
 
-type ToastDescriptionProps = ToastPrimitive.ToastDescriptionProps & { class?: string | undefined }
+type ToastDescriptionProps<T extends ValidComponent = "div"> = ToastPrimitive.ToastDescriptionProps<T> & { class?: string | undefined }
 
 const ToastDescription = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ToastDescriptionProps>
+  props: PolymorphicProps<T, ToastDescriptionProps<T>>
 ) => {
   const [local, others] = splitProps(props as ToastDescriptionProps, ["class"])
   return <ToastPrimitive.Description class={cn("text-sm opacity-90", local.class)} {...others} />

--- a/apps/docs/src/registry/ui/toggle-group.tsx
+++ b/apps/docs/src/registry/ui/toggle-group.tsx
@@ -12,11 +12,11 @@ const ToggleGroupContext = createContext<VariantProps<typeof toggleVariants>>({
   variant: "default"
 })
 
-type ToggleGroupRootProps = ToggleGroupPrimitive.ToggleGroupRootProps &
+type ToggleGroupRootProps<T extends ValidComponent = "div"> = ToggleGroupPrimitive.ToggleGroupRootProps<T> &
   VariantProps<typeof toggleVariants> & { class?: string | undefined; children?: JSX.Element }
 
 const ToggleGroup = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, ToggleGroupRootProps>
+  props: PolymorphicProps<T, ToggleGroupRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as ToggleGroupRootProps, [
     "class",
@@ -46,11 +46,11 @@ const ToggleGroup = <T extends ValidComponent = "div">(
   )
 }
 
-type ToggleGroupItemProps = ToggleGroupPrimitive.ToggleGroupItemProps &
+type ToggleGroupItemProps<T extends ValidComponent = "button"> = ToggleGroupPrimitive.ToggleGroupItemProps<T> &
   VariantProps<typeof toggleVariants> & { class?: string | undefined }
 
 const ToggleGroupItem = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, ToggleGroupItemProps>
+  props: PolymorphicProps<T, ToggleGroupItemProps<T>>
 ) => {
   const [local, others] = splitProps(props as ToggleGroupItemProps, ["class", "size", "variant"])
   const context = useContext(ToggleGroupContext)

--- a/apps/docs/src/registry/ui/toggle.tsx
+++ b/apps/docs/src/registry/ui/toggle.tsx
@@ -29,11 +29,11 @@ const toggleVariants = cva(
   }
 )
 
-type ToggleButtonRootProps = ToggleButtonPrimitive.ToggleButtonRootProps &
+type ToggleButtonRootProps<T extends ValidComponent = "button"> = ToggleButtonPrimitive.ToggleButtonRootProps<T> &
   VariantProps<typeof toggleVariants> & { class?: string | undefined }
 
 const Toggle = <T extends ValidComponent = "button">(
-  props: PolymorphicProps<T, ToggleButtonRootProps>
+  props: PolymorphicProps<T, ToggleButtonRootProps<T>>
 ) => {
   const [local, others] = splitProps(props as ToggleButtonRootProps, ["class", "variant", "size"])
   return (

--- a/apps/docs/src/registry/ui/tooltip.tsx
+++ b/apps/docs/src/registry/ui/tooltip.tsx
@@ -11,10 +11,10 @@ const Tooltip: Component<TooltipPrimitive.TooltipRootProps> = (props) => {
   return <TooltipPrimitive.Root gutter={4} {...props} />
 }
 
-type TooltipContentProps = TooltipPrimitive.TooltipContentProps & { class?: string | undefined }
+type TooltipContentProps<T extends ValidComponent = "div"> = TooltipPrimitive.TooltipContentProps<T> & { class?: string | undefined }
 
 const TooltipContent = <T extends ValidComponent = "div">(
-  props: PolymorphicProps<T, TooltipContentProps>
+  props: PolymorphicProps<T, TooltipContentProps<T>>
 ) => {
   const [local, others] = splitProps(props as TooltipContentProps, ["class"])
   return (


### PR DESCRIPTION
Non breaking update to `@kobalte/core@0.13.2` (https://github.com/kobaltedev/kobalte/pull/420).
Fixes ref attribute & more precise event handler types.

~~Not release yet!~~ Released!