### PR TITLE
docs: improve button docs with another link option

### DIFF
--- a/apps/docs/src/routes/docs/components/button.mdx
+++ b/apps/docs/src/routes/docs/components/button.mdx
@@ -62,3 +62,18 @@ import { buttonVariants } from "~/components/ui/button"
 ```tsx
 <a class={buttonVariants({ variant: "outline" })}>Click here</a>
 ```
+
+Alternatively, you can set the `as` parameter with the component you want to use as your link.
+```tsx
+import { A } from "@solidjs/router";
+```
+
+```tsx
+<Button as={A} href="/login">Login</Button>
+```
+
+Or set it as `"a"`, in case you want to use the standard HTML anchor tag.
+
+```tsx
+<Button as="a" href="/login">Login</Button>
+```


### PR DESCRIPTION
Hi!

Thanks for the great work! Here's a PR improving the docs for the Button by adding another way of creating links, which may be more convenient for some people. Since this is an already built into Kobalte, it's a no brainer 😉

I based the new text in the shadcn docs, which has pretty much the same alternative Link option ( by using the `asChild` prop )