### PR TITLE
fix(docs): Incorrect type in Carousel Docs API example

### DIFF
--- a/apps/docs/src/routes/docs/components/carousel.mdx
+++ b/apps/docs/src/routes/docs/components/carousel.mdx
@@ -186,7 +186,7 @@ Use a state and the `setApi` props to get an instance of the carousel API.
 import type { CarouselApi } from "~/components/ui/carousel"
 
 export function Example() {
-  const [api, setApi] = createSignal<CarouselApi>()
+  const [api, setApi] = createSignal<ReturnType<CarouselApi>>()
   const [current, setCurrent] = createSignal(0)
   const [count, setCount] = createSignal(0)
 


### PR DESCRIPTION
Fixes a small type issue in the documentation for the Carousel component.