### PR TITLE
Fix styling of TextFieldDescription

### DIFF
--- a/apps/docs/src/registry/ui/text-field.tsx
+++ b/apps/docs/src/registry/ui/text-field.tsx
@@ -77,8 +77,8 @@ const labelVariants = cva(
     variants: {
       variant: {
         label: "data-[invalid]:text-destructive",
-        description: "text-destructive",
-        error: "font-normal text-muted-foreground"
+        error: "text-destructive",
+        description: "font-normal text-muted-foreground"
       }
     },
     defaultVariants: {


### PR DESCRIPTION
I believe the styling of the text field label / description may have accidentally been swapped