### PR TITLE
feat: setup project with solidui-cli using deno

### DIFF
--- a/.changeset/huge-bars-move.md
+++ b/.changeset/huge-bars-move.md
@@ -1,0 +1,5 @@
+---
+"solidui-cli": patch
+---
+
+feat: support deno

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -148,7 +148,12 @@ export const add = new Command()
         // install dependencies
         if (item.dependencies?.length) {
           const packageManager = await getPackageManager(cwd)
-          await execa(packageManager, ["add", ...item.dependencies], { cwd })
+          await execa(packageManager, [
+            "add",
+            ...(packageManager === "deno"
+              ? item.dependencies.map((dep) => `npm:${dep}`)
+              : item.dependencies),
+          ], { cwd });
         }
       }
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -150,9 +150,8 @@ export const add = new Command()
           const packageManager = await getPackageManager(cwd)
           await execa(packageManager, [
             "add",
-            ...(packageManager === "deno"
-              ? item.dependencies.map((dep) => `npm:${dep}`)
-              : item.dependencies),
+            packageManager === "deno" ? "--npm" : "",
+            ...item.dependencies,
           ], { cwd });
         }
       }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -99,9 +99,8 @@ export const init = new Command()
       const packageManager = await getPackageManager(cwd)
       await execa(packageManager, [
         "add",
-        ...(packageManager === "deno"
-          ? PROJECT_DEPENDENCIES.map((dep) => `npm:${dep}`)
-          : PROJECT_DEPENDENCIES),
+        packageManager === "deno" ? "--npm" : "",
+        ...PROJECT_DEPENDENCIES,
       ], { cwd });
 
       spinner.stop(`Dependencies installed.`)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -97,7 +97,12 @@ export const init = new Command()
       spinner.start(`Installing dependencies...`)
 
       const packageManager = await getPackageManager(cwd)
-      await execa(packageManager, ["add", ...PROJECT_DEPENDENCIES], { cwd })
+      await execa(packageManager, [
+        "add",
+        ...(packageManager === "deno"
+          ? PROJECT_DEPENDENCIES.map((dep) => `npm:${dep}`)
+          : PROJECT_DEPENDENCIES),
+      ], { cwd });
 
       spinner.stop(`Dependencies installed.`)
 

--- a/packages/cli/src/utils/get-package-manager.ts
+++ b/packages/cli/src/utils/get-package-manager.ts
@@ -2,7 +2,7 @@ import { detect } from "@antfu/ni"
 
 export async function getPackageManager(
   targetDir: string
-): Promise<"yarn" | "pnpm" | "bun" | "npm"> {
+): Promise<"yarn" | "pnpm" | "bun" | "npm" | "deno"> {
   const packageManager = await detect({ programmatic: true, cwd: targetDir })
 
   if (packageManager === "yarn@berry") return "yarn"


### PR DESCRIPTION
Using `deno run npm:solidui-cli@latest init`.

When doing it before it would fail because it needs the `npm:` prefix on each dependency which it didn't.