### PR TITLE
fix(packages/cli): package manager bun error

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -152,7 +152,7 @@ export const add = new Command()
             "add",
             packageManager === "deno" ? "--npm" : "",
             ...item.dependencies,
-          ], { cwd });
+          ].filter(Boolean), { cwd });
         }
       }
 


### PR DESCRIPTION
Error caused by #181.

Run `bunx solidui-cli@latest add button`, error:

`ExecaError: Command failed with exit code 1: bun add '' '@kobalte/core'`