### PR TITLE
Fix conditional argument for package manager command

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -150,9 +150,9 @@ export const add = new Command()
           const packageManager = await getPackageManager(cwd)
           await execa(packageManager, [
             "add",
-            packageManager === "deno" ? "--npm" : "",
+            packageManager === "deno" ? "--npm" : undefined,
             ...item.dependencies,
-          ], { cwd });
+          ].filter(Boolean), { cwd });
         }
       }
 


### PR DESCRIPTION
when using bun its getting an error like: 

`ExecaError: Command failed with exit code 1: bun add '' '@kobalte/core'`

filtering the array with boolean will fix.